### PR TITLE
Immutable components of parent kernel

### DIFF
--- a/src/Ninject.Extensions.ChildKernel.Test/Ninject.Extensions.ChildKernel.Test.csproj
+++ b/src/Ninject.Extensions.ChildKernel.Test/Ninject.Extensions.ChildKernel.Test.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ninject.Extensions.ChildKernel</RootNamespace>
     <AssemblyName>Ninject.Extensions.ChildKernel.Test</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Ninject.snk</AssemblyOriginatorKeyFile>
@@ -34,7 +34,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,7 +62,7 @@
     </Reference>
     <Reference Include="Ninject, Version=2.1.0.58, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Ninject\net-3.5\Ninject.dll</HintPath>
+      <HintPath>..\..\lib\Ninject\net-4.5\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/src/Ninject.Extensions.ChildKernel/ChildActivationCache.cs
+++ b/src/Ninject.Extensions.ChildKernel/ChildActivationCache.cs
@@ -21,6 +21,7 @@ namespace Ninject.Extensions.ChildKernel
 {
     using Ninject.Activation.Caching;
     using Ninject.Components;
+    using System;
 
     /// <summary>
     /// The activation cache of child kernels.
@@ -38,6 +39,11 @@ namespace Ninject.Extensions.ChildKernel
         /// <param name="kernel">The kernel.</param>
         public ChildActivationCache(IKernel kernel)
         {
+            if (kernel == null)
+            {
+                throw new ArgumentNullException(nameof(kernel));
+            }
+            
             this.parentCache = ((IChildKernel)kernel).ParentResolutionRoot.Get<IKernel>().Components.Get<IActivationCache>();
         }
 

--- a/src/Ninject.Extensions.ChildKernel/ChildKernel.cs
+++ b/src/Ninject.Extensions.ChildKernel/ChildKernel.cs
@@ -19,43 +19,44 @@
 
 namespace Ninject.Extensions.ChildKernel
 {
-    using System;
     using System.Collections.Generic;
     using Ninject;
     using Ninject.Activation;
     using Ninject.Activation.Caching;
+    using Ninject.Activation.Strategies;
+    using Ninject.Components;
+    using Ninject.Injection;
     using Ninject.Modules;
+    using Ninject.Planning;
+    using Ninject.Planning.Bindings.Resolvers;
+    using Ninject.Planning.Strategies;
+    using Ninject.Selection;
     using Ninject.Selection.Heuristics;
     using Ninject.Syntax;
+    using System;
 
     /// <summary>
     /// This is a kernel with a parent kernel. Any binding that can not be resolved by this kernel is forwarded to the
     /// parent.
     /// </summary>
-    public class ChildKernel : StandardKernel, IChildKernel
+    public class ChildKernel : KernelBase, IChildKernel
     {
-        /// <summary>
-        /// The parent kernel.
-        /// </summary>
-        private readonly IResolutionRoot parent;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildKernel"/> class.
         /// </summary>
         /// <param name="parent">The parent.</param>
         /// <param name="modules">The modules.</param>
         public ChildKernel(IResolutionRoot parent, params INinjectModule[] modules)
-            : base(modules)
+            : base(CreateComponentContainerOfStandartKernel(), new NinjectSettings(), modules)
         {
-            this.parent = parent;
+            if (parent == null)
+            {
+                throw new ArgumentNullException(nameof(parent));
+            }
             
-            this.Components.RemoveAll<IActivationCache>();
-            this.Components.Add<IActivationCache, ChildActivationCache>(); 
-          
-            this.Components.RemoveAll<IConstructorScorer>();
-            this.Components.Add<IConstructorScorer, ChildKernelConstructorScorer>();
+            ParentResolutionRoot = parent;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildKernel"/> class.
         /// </summary>
@@ -63,23 +64,60 @@ namespace Ninject.Extensions.ChildKernel
         /// <param name="settings">The settings.</param>
         /// <param name="modules">The modules.</param>
         public ChildKernel(IResolutionRoot parent, INinjectSettings settings, params INinjectModule[] modules)
-            : base(settings, modules)
+            : base(CreateComponentContainerOfStandartKernel(settings), settings, modules)
         {
-            this.parent = parent;
+            if (parent == null)
+            {
+                throw new ArgumentNullException(nameof(parent));
+            }
+            
+            ParentResolutionRoot = parent;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildKernel"/> class.
+        /// </summary>
+        /// <param name="parent">The parent.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="components">The components.</param>
+        /// <param name="modules">The modules.</param>
+        public ChildKernel(
+            IResolutionRoot parent,
+            INinjectSettings settings,
+            IComponentContainer components,
+            params INinjectModule[] modules)
+            : base(new ChildKernelComponentContainer(components), settings, modules)
+        {
+            if (parent == null)
+            {
+                throw new ArgumentNullException(nameof(parent));
+            }
+            
+            ParentResolutionRoot = parent;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildKernel"/> class.
+        /// </summary>
+        /// <param name="parent">The parent.</param>
+        /// <param name="modules">The modules.</param>
+        public ChildKernel(IKernel parent, params INinjectModule[] modules)
+            : base(new ChildKernelComponentContainer(parent.Components), parent.Settings, modules)
+        {
+            if (parent == null)
+            {
+                throw new ArgumentNullException(nameof(parent));
+            }
+            
+            ParentResolutionRoot = parent;
         }
 
         /// <summary>
         /// Gets the parent resolution root.
         /// </summary>
         /// <value>The parent  resolution root.</value>
-        public IResolutionRoot ParentResolutionRoot
-        {
-            get
-            {
-                return this.parent;
-            }
-        }
-        
+        public IResolutionRoot ParentResolutionRoot { get; }
+
         /// <summary>
         /// Determines whether the specified request can be resolved.
         /// </summary>
@@ -89,7 +127,7 @@ namespace Ninject.Extensions.ChildKernel
         /// </returns>
         public override bool CanResolve(IRequest request)
         {
-            return base.CanResolve(request) || this.parent.CanResolve(request, true);
+            return base.CanResolve(request) || this.ParentResolutionRoot.CanResolve(request, true);
         }
 
         /// <summary>
@@ -102,7 +140,7 @@ namespace Ninject.Extensions.ChildKernel
         /// </returns>
         public override bool CanResolve(IRequest request, bool ignoreImplicitBindings)
         {
-            return base.CanResolve(request, ignoreImplicitBindings) || this.parent.CanResolve(request, true);
+            return base.CanResolve(request, ignoreImplicitBindings) || this.ParentResolutionRoot.CanResolve(request, true);
         }
 
         /// <summary>
@@ -120,9 +158,9 @@ namespace Ninject.Extensions.ChildKernel
                 return base.Resolve(request);
             }
 
-            if (this.parent.CanResolve(request, true))
+            if (this.ParentResolutionRoot.CanResolve(request, true))
             {
-                return this.parent.Resolve(request);
+                return this.ParentResolutionRoot.Resolve(request);
             }
 
             try
@@ -133,7 +171,7 @@ namespace Ninject.Extensions.ChildKernel
             {
                 try
                 {
-                    return this.parent.Resolve(request);
+                    return this.ParentResolutionRoot.Resolve(request);
                 }
                 catch (ActivationException)
                 {
@@ -141,6 +179,61 @@ namespace Ninject.Extensions.ChildKernel
 
                 throw;
             }
+        }
+
+        protected override void AddComponents()
+        {
+        }
+
+        protected override IKernel KernelInstance => this;
+
+        /// <summary>
+        /// Create container with components of <see cref="StandardKernel"/>
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        private static IComponentContainer CreateComponentContainerOfStandartKernel(INinjectSettings settings = null)
+        {
+            var container = new ChildKernelComponentContainer();
+
+            container.Add<IPlanner, Planner>();
+            container.Add<IPlanningStrategy, ConstructorReflectionStrategy>();
+            container.Add<IPlanningStrategy, PropertyReflectionStrategy>();
+            container.Add<IPlanningStrategy, MethodReflectionStrategy>();
+            container.Add<IInjectionHeuristic, StandardInjectionHeuristic>();
+            container.Add<IPipeline, Pipeline>();
+
+            if (settings != null && !settings.ActivationCacheDisabled)
+            {
+                container.Add<IActivationStrategy, ActivationCacheStrategy>();
+            }
+
+            container.Add<IActivationStrategy, PropertyInjectionStrategy>();
+            container.Add<IActivationStrategy, MethodInjectionStrategy>();
+            container.Add<IActivationStrategy, InitializableStrategy>();
+            container.Add<IActivationStrategy, StartableStrategy>();
+            container.Add<IActivationStrategy, BindingActionStrategy>();
+            container.Add<IActivationStrategy, DisposableStrategy>();
+            container.Add<IBindingResolver, StandardBindingResolver>();
+            container.Add<IBindingResolver, OpenGenericBindingResolver>();
+            container.Add<IMissingBindingResolver, DefaultValueBindingResolver>();
+            container.Add<IMissingBindingResolver, SelfBindingResolver>();
+
+            if (settings != null && !settings.UseReflectionBasedInjection)
+            {
+                container.Add<IInjectorFactory, DynamicMethodInjectorFactory>();
+            }
+            else
+            {
+                container.Add<IInjectorFactory, ReflectionInjectorFactory>();
+            }
+
+            container.Add<ICache, Cache>();
+            container.Add<ICachePruner, GarbageCollectionCachePruner>();
+            container.Add<IModuleLoader, ModuleLoader>();
+            container.Add<IModuleLoaderPlugin, CompiledModuleLoaderPlugin>();
+            container.Add<IAssemblyNameRetriever, AssemblyNameRetriever>();
+
+            return container;
         }
     }
 }

--- a/src/Ninject.Extensions.ChildKernel/ChildKernelComponentContainer.cs
+++ b/src/Ninject.Extensions.ChildKernel/ChildKernelComponentContainer.cs
@@ -1,0 +1,194 @@
+﻿namespace Ninject.Extensions.ChildKernel
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Ninject.Activation.Caching;
+    using Ninject.Components;
+    using Ninject.Infrastructure.Disposal;
+    using Ninject.Selection;
+    using Ninject.Selection.Heuristics;
+
+    public class ChildKernelComponentContainer : DisposableObject, IComponentContainer
+    {
+        private readonly IComponentContainer _parentComponentContainer;
+        private readonly IComponentContainer _childComponentContainer;
+
+        private readonly Type[] _immutableComponents;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildKernelComponentContainer"/> class.
+        /// </summary>
+        /// <param name="parentComponentContainer">The parent component container.</param>
+        public ChildKernelComponentContainer(IComponentContainer parentComponentContainer)
+        {
+            if (parentComponentContainer == null)
+            {
+                throw new ArgumentNullException(nameof(parentComponentContainer));
+            }
+            
+            _parentComponentContainer = parentComponentContainer;
+            _childComponentContainer = new ComponentContainer();
+            
+            _childComponentContainer.Add<IActivationCache, ChildActivationCache>();
+            _childComponentContainer.Add<IConstructorScorer, ChildKernelConstructorScorer>();
+            _childComponentContainer.Add<ISelector, Selector>();
+            _childComponentContainer.Kernel = Kernel;
+
+            _immutableComponents = new[]
+            {
+                typeof(IActivationCache),
+                typeof(IConstructorScorer),
+                typeof(ISelector)
+            };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildKernelComponentContainer"/> class.
+        /// </summary>
+        public ChildKernelComponentContainer(): this(new ComponentContainer())
+        {
+        }
+
+        /// <summary>
+        /// Releases resources held by the object.
+        /// </summary>
+        /// <param name="disposing"><c>True</c> if called manually, otherwise by GC.</param>
+        public override void Dispose(bool disposing)
+        {
+            _childComponentContainer.Dispose();
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Registers a component in the container.
+        /// </summary>
+        /// <typeparam name="TComponent">The component type.</typeparam>
+        /// <typeparam name="TImplementation">The component's implementation type.</typeparam>
+        public void Add<TComponent, TImplementation>()
+            where TComponent : INinjectComponent
+            where TImplementation : TComponent, INinjectComponent
+        {
+            CheckImmutableComponent(typeof(TComponent));
+            this._childComponentContainer.Add<TComponent, TImplementation>();
+        }
+
+        /// <summary>
+        /// Registers a transient component in the container.
+        /// </summary>
+        /// <typeparam name="TComponent">The component type.</typeparam>
+        /// <typeparam name="TImplementation">The component's implementation type.</typeparam>
+        public void AddTransient<TComponent, TImplementation>()
+            where TComponent : INinjectComponent
+            where TImplementation : TComponent, INinjectComponent
+        {
+            this._childComponentContainer.AddTransient<TComponent, TImplementation>();
+        }
+
+        /// <summary>
+        /// Removes all registrations for the specified component.
+        /// </summary>
+        /// <typeparam name="T">The component type.</typeparam>
+        public void RemoveAll<T>()
+            where T : INinjectComponent
+        {
+            this._childComponentContainer.RemoveAll<T>();
+        }
+
+        /// <summary>
+        /// Removes the specified registration.
+        /// </summary>
+        /// <typeparam name="T">The component type.</typeparam>
+        /// <typeparam name="TImplementation">The implementation type.</typeparam>
+        public void Remove<T, TImplementation>()
+            where T : INinjectComponent
+            where TImplementation : T
+        {
+            CheckImmutableComponent(typeof(T));
+            this._childComponentContainer.Remove<T, TImplementation>();
+        }
+
+        /// <summary>
+        /// Removes all registrations for the specified component.
+        /// </summary>
+        /// <param name="component">The component type.</param>
+        public void RemoveAll(Type component)
+        {
+            CheckImmutableComponent(component);
+            this._childComponentContainer.RemoveAll(component);
+        }
+
+        /// <summary>
+        /// Gets one instance of the specified component.
+        /// </summary>
+        /// <typeparam name="T">The component type.</typeparam>
+        /// <returns>The instance of the component.</returns>
+        public T Get<T>()
+            where T : INinjectComponent
+        {
+            return (T)this.Get(typeof(T));
+        }
+
+        /// <summary>
+        /// Gets all available instances of the specified component.
+        /// </summary>
+        /// <typeparam name="T">The component type.</typeparam>
+        /// <returns>A series of instances of the specified component.</returns>
+        public IEnumerable<T> GetAll<T>()
+            where T : INinjectComponent
+        {
+            return this.GetAll(typeof(T)).Cast<T>();
+        }
+
+        /// <summary>
+        /// Gets one instance of the specified component.
+        /// </summary>
+        /// <param name="component">The component type.</param>
+        /// <returns>The instance of the component.</returns>
+        public object Get(Type component)
+        {
+            try
+            {
+                return this._childComponentContainer.Get(component);
+            }
+            catch (InvalidOperationException)
+            {
+                return this._parentComponentContainer.Get(component);
+            }
+        }
+
+        /// <summary>
+        /// Gets all available instances of the specified component.
+        /// </summary>
+        /// <param name="component">The component type.</param>
+        /// <returns>A series of instances of the specified component.</returns>
+        public IEnumerable<object> GetAll(Type component)
+        {
+            return this._childComponentContainer.GetAll(component)
+                .Concat(this._parentComponentContainer.GetAll(component));
+        }
+
+        /// <summary>
+        /// The kernel
+        /// </summary>
+        public IKernel Kernel {
+            get
+            {
+                return this._childComponentContainer.Kernel;
+            }
+            set
+            { 
+                this._childComponentContainer.Kernel = value;
+            } 
+        }
+
+        private void CheckImmutableComponent(Type component)
+        {
+            if (_immutableComponents.Any(t => t == component))
+            {
+                throw new InvalidOperationException($"Component {nameof(component)} is immutable in childKernel.");
+            }
+        }
+    }
+}

--- a/src/Ninject.Extensions.ChildKernel/Ninject.Extensions.ChildKernel.csproj
+++ b/src/Ninject.Extensions.ChildKernel/Ninject.Extensions.ChildKernel.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ninject.Extensions.ChildKernel</RootNamespace>
     <AssemblyName>Ninject.Extensions.ChildKernel</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Ninject.snk</AssemblyOriginatorKeyFile>
@@ -34,7 +34,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,7 +62,7 @@
   <ItemGroup>
     <Reference Include="Ninject, Version=2.1.0.58, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Ninject\net-3.5\Ninject.dll</HintPath>
+      <HintPath>..\..\lib\Ninject\net-4.5\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/src/Ninject.Extensions.ChildKernel/Ninject.Extensions.ChildKernel.csproj
+++ b/src/Ninject.Extensions.ChildKernel/Ninject.Extensions.ChildKernel.csproj
@@ -83,6 +83,7 @@
     </Compile>
     <Compile Include="ChildActivationCache.cs" />
     <Compile Include="ChildKernel.cs" />
+    <Compile Include="ChildKernelComponentContainer.cs" />
     <Compile Include="ChildKernelConstructorScorer.cs" />
     <Compile Include="IChildKernel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Ninject.Extensions.ChildKernel/Properties/AssemblyInfo.cs
+++ b/src/Ninject.Extensions.ChildKernel/Properties/AssemblyInfo.cs
@@ -29,8 +29,5 @@ using System.Security;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("39527a43-4711-438a-b3a8-63dc45fe45ee")]
 
-#if !NO_PARTIAL_TRUST
-[assembly: AllowPartiallyTrustedCallers]
-#endif
 [assembly: AssemblyDescriptionAttribute("Ninject extension that allows that child kernels can be defined.")]
 


### PR DESCRIPTION
In the current implementation: the destruction of childKernel causes the destruction of parent kernel components.
This commits fix this.
+ Up .NET Framework to 4.5